### PR TITLE
ci: update ci to use updated modflow6 repo scripts

### DIFF
--- a/.github/common/install-python-std.sh
+++ b/.github/common/install-python-std.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pip install wheel
+pip install requests appdirs numpy matplotlib pytest pytest-xdist meson ninja
+pip install https://github.com/modflowpy/flopy/zipball/develop
+pip install https://github.com/modflowpy/pymake/zipball/master

--- a/.github/intel-scripts/build_windows.bat
+++ b/.github/intel-scripts/build_windows.bat
@@ -7,6 +7,7 @@ REM SPDX-License-Identifier: MIT
 for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
 @call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
 
+echo %VS_VER%
 echo %LATEST_VERSION%
 echo "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
 echo %ONEAPI_ROOT%

--- a/.github/intel-scripts/build_windows.bat
+++ b/.github/intel-scripts/build_windows.bat
@@ -2,9 +2,6 @@ REM SPDX-FileCopyrightText: 2020 Intel Corporation
 REM
 REM SPDX-License-Identifier: MIT
 
-set LANGUAGE=%1
-set VS_VER=%2
-
 @call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" %VS_VER%
 
 for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"

--- a/.github/intel-scripts/build_windows.bat
+++ b/.github/intel-scripts/build_windows.bat
@@ -5,13 +5,8 @@ REM SPDX-License-Identifier: MIT
 set LANGUAGE=%1
 set VS_VER=%2
 
-IF "%VS_VER%"=="2017_build_tools" (
-@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-)
+@call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" %VS_VER%
 
-IF "%VS_VER%"=="2019_build_tools" (
-@call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-)
 for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
 @call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
 

--- a/.github/intel-scripts/install_windows.bat
+++ b/.github/intel-scripts/install_windows.bat
@@ -1,15 +1,16 @@
-REM SPDX-FileCopyrightText: 2020 Intel Corporation
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
 REM
 REM SPDX-License-Identifier: MIT
 
 set URL=%1
 set COMPONENTS=%2
 
-curl.exe --output webimage.exe --url %URL% --retry 5 --retry-delay 5
-start /b /wait webimage.exe -s -x -f webimage_extracted --log extract.log
-del webimage.exe
+curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+del %TEMP%\webimage.exe
 if "%COMPONENTS%"=="" (
-  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
 ) else (
-  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
 )
+rd /s/q "webimage_extracted"

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -39,226 +39,202 @@ jobs:
         shell: bash
 
     env:
-      WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18417/w_HPCKit_p_2022.1.0.93_offline.exe
-      LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18438/l_HPCKit_p_2022.1.1.97_offline.sh
-      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18341/m_HPCKit_p_2022.1.0.86_offline.dmg
+      WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
+      LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh
+      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18681/m_HPCKit_p_2022.2.0.158_offline.dmg
       WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
       LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
       MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
+      FC: ifort
 
     steps:
-    - name: Checkout this github repo
-      uses: actions/checkout@v2.3.4
+      - name: Checkout this github repo
+        uses: actions/checkout@v2.3.4
 
-    - name: cache install ifort on linux
-      if: runner.os == 'Linux'
-      id: cache-install-linux
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/intel/oneapi
-        key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_linux.sh') }}
+      - name: Setup Python
+        uses: actions/setup-python@v4.0.0
+        with:
+          python-version: 3.9
 
-    - name: install ifort on linux
-      if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
+      - name: Install python packages
+        run: |
+          .github/common/install-python-std.sh
 
-    - name: cache install ifort on macos
-      if: runner.os == 'macOS'
-      id: cache-install-macos
-      uses: actions/cache@v2
-      with:
-        path: /opt/intel/oneapi
-        key: install-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_FORTRAN_COMPONENTS }}
+      - name: Print python package versions
+        run: |
+          pip list
 
-    - name: install ifort on macos
-      if: runner.os == 'macOS' && steps.cache-install-macos.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_macos.sh $MACOS_HPCKIT_URL $MACOS_FORTRAN_COMPONENTS
+      - name: cache install ifort on linux
+        if: runner.os == 'Linux'
+        id: cache-install-linux
+        uses: actions/cache@v2
+        with:
+          path: |
+            /opt/intel/oneapi
+          key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_linux.sh') }}
 
-    - name: cache install ifort on windows
-      if: runner.os == 'Windows'
-      id: cache-install-windows
-      uses: actions/cache@v2
-      with:
-        path: C:\Program Files (x86)\Intel\oneAPI
-        key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_windows.sh') }}
+      - name: install ifort on linux
+        if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
 
-    - name: install ifort on windows
-      if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
+      - name: cache install ifort on macos
+        if: runner.os == 'macOS'
+        id: cache-install-macos
+        uses: actions/cache@v2
+        with:
+          path: /opt/intel/oneapi
+          key: install-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_FORTRAN_COMPONENTS }}
 
-    - name: setup-conda
-      uses: s-weigand/setup-conda@v1.0.5
-      with:
-        update-conda: true
+      - name: install ifort on macos
+        if: runner.os == 'macOS' && steps.cache-install-macos.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_macos.sh $MACOS_HPCKIT_URL $MACOS_FORTRAN_COMPONENTS
 
-    - name: Install python packages
-      run: |
-        conda info
-        conda install pip requests appdirs nose wheel
-        # use pip to install numpy and matplotlib because of a windows issue
-        pip install numpy matplotlib
-        pip install https://github.com/modflowpy/flopy/zipball/develop
-        pip install https://github.com/modflowpy/pymake/zipball/master
+      - name: cache install ifort on windows
+        if: runner.os == 'Windows'
+        id: cache-install-windows
+        uses: actions/cache@v2
+        with:
+          path: C:\Program Files (x86)\Intel\oneAPI
+          key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_windows.sh') }}
 
-    - name: Clone MODFLOW 6 repo
-      run: |
-        git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
+      - name: install ifort on windows
+        if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
 
-    - name: Determine MODFLOW 6 branch
-      run: |
-        pwd
-        cd ./modflow6/
-        pwd
-        git branch
-        cd ../
-        pwd
-        ls ./
+      - name: Clone MODFLOW 6 repo
+        run: |
+          git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
 
-    - name: Update flopy MODFLOW 6 classes
-      run: |
-        cd ./modflow6/autotest
-        python update_flopy.py
-        cd ../../
+      - name: Determine MODFLOW 6 branch
+        run: |
+          pwd
+          cd ./modflow6/
+          pwd
+          git branch
+          cd ../
+          pwd
+          ls ./
 
-    - name: Print python package versions
-      shell: python
-      run: |
-        import sys
-        import nose
-        import numpy as np
-        import matplotlib as mpl
-        import flopy
-        import pymake
-        flopypth = flopy.__path__[0]
-        pymakepth = pymake.__path__[0]
-        print("python version:     {}".format(sys.version))
-        print("nosetest version:   {}".format(nose.__version__))
-        print("numpy version:      {}".format(np.__version__))
-        print("matplotlib version: {}".format(mpl.__version__))
-        print("flopy version:      {}".format(flopy.__version__))
-        print("pymake version:     {}".format(pymake.__version__))
-        print("")
-        print("flopy is installed in:  {}".format(flopypth))
-        print("pymake is installed in: {}".format(pymakepth))
+      - name: Update flopy MODFLOW 6 classes
+        working-directory: modflow6/autotest
+        run: |
+          python update_flopy.py
 
-    - name: Build and zip applications on linux and MacOS
-      if: runner.os == 'Linux' || runner.os == 'macOS'
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        cd ./modflow6/distribution/
-        python build_nightly.py -fc ifort
-        cd ../../
+      - name: Build and zip applications on linux and MacOS
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        working-directory: modflow6/distribution
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          pytest -v build_nightly.py
 
-    - name: Build and zip applications on Windows
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        call ".github/intel-scripts/ifortvars_windows.bat"
-        cd ./modflow6/distribution/
-        python build_nightly.py -fc ifort
-        cd ../../
+      - name: Build and zip applications on Windows
+        if: runner.os == 'Windows'
+        working-directory: modflow6/distribution
+        shell: cmd
+        run: |
+          call "../../.github/intel-scripts/ifortvars_windows.bat"
+          pytest -v build_nightly.py
 
-    - name: Move the build zip file
-      run: |
-        mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
-        ls -l ./
+      - name: Move the build zip file
+        run: |
+          mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
+          ls -l ./
 
-    # Build LaTeX document
-    - name: Copy the modflow6/docs directory
-      if: runner.os == 'Linux'
-      shell: python
-      run: |
-        import shutil
-        src = "/home/runner/work/modflow6-nightly-build/modflow6-nightly-build/modflow6/doc/"
-        dst = "./doc/"
-        shutil.copytree(src, dst)
+      # Build LaTeX document
+      - name: Copy the modflow6/docs directory
+        if: runner.os == 'Linux'
+        shell: python
+        run: |
+          import shutil
+          src = "/home/runner/work/modflow6-nightly-build/modflow6-nightly-build/modflow6/doc/"
+          dst = "./doc/"
+          shutil.copytree(src, dst)
 
-    - name: Install TeX Live
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt install texlive-latex-extra texlive-science texlive-font-utils
+      - name: Install TeX Live
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt install texlive-latex-extra texlive-science texlive-font-utils
 
-    - name: Clone USGS LaTeX repo
-      if: runner.os == 'Linux'
-      run: |
-        git clone https://github.com/MODFLOW-USGS/usgslatex.git usgslatex
+      - name: Clone USGS LaTeX repo
+        if: runner.os == 'Linux'
+        run: |
+          git clone https://github.com/MODFLOW-USGS/usgslatex.git usgslatex
 
-    - name: Install USGS LaTeX style files and Univers font
-      if: runner.os == 'Linux'
-      working-directory: ./usgslatex/usgsLaTeX
-      run: |
-        sudo ./install.sh --all-users
+      - name: Install USGS LaTeX style files and Univers font
+        if: runner.os == 'Linux'
+        working-directory: ./usgslatex/usgsLaTeX
+        run: |
+          sudo ./install.sh --all-users
 
-    - name: Build mf6io latex document
-      if: runner.os == 'Linux'
-      shell: python
-      run: |
-        import sys
-        import subprocess
+      - name: Build mf6io latex document
+        if: runner.os == 'Linux'
+        shell: python
+        run: |
+          import sys
+          import subprocess
+          
+          ws = "./modflow6/doc/mf6io/"
+          bibnam = "mf6io"
+          texnam = bibnam + ".tex"
+          cmds = [
+                  ["pdflatex", texnam],
+                  ["bibtex", bibnam],
+                  ["pdflatex", texnam],
+                  ["pdflatex", texnam],
+                 ]
+          for cmd in cmds:
+              print("running command...'{}'".format(" ".join(cmd)))
+              with subprocess.Popen(cmd,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                    cwd=ws) as process:
+                  stdout, stderr = process.communicate(timeout=10)
+                  if stdout:
+                      stdout = stdout.decode()
+                      print(stdout)
+                  if stderr:
+                      print("\n\nError condition occurred:\n")
+                      stderr = stderr.decode()
+                      print(stderr)
 
-        ws = "./modflow6/doc/mf6io/"
-        bibnam = "mf6io"
-        texnam = bibnam + ".tex"
-        cmds = [
-                ["pdflatex", texnam],
-                ["bibtex", bibnam],
-                ["pdflatex", texnam],
-                ["pdflatex", texnam],
-               ]
-        for cmd in cmds:
-            print("running command...'{}'".format(" ".join(cmd)))
-            with subprocess.Popen(cmd,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT,
-                                  cwd=ws) as process:
-                stdout, stderr = process.communicate(timeout=10)
-                if stdout:
-                    stdout = stdout.decode()
-                    print(stdout)
-                if stderr:
-                    print("\n\nError condition occurred:\n")
-                    stderr = stderr.decode()
-                    print(stderr)
+      - name: Move the LaTeX document
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          ls -la ./modflow6/doc/mf6io/
+          mv ./modflow6/doc/mf6io/mf6io.pdf mf6io.pdf
+          ls -la ./
 
-    - name: Move the LaTeX document
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        ls -la ./modflow6/doc/mf6io/
-        mv ./modflow6/doc/mf6io/mf6io.pdf mf6io.pdf
-        ls -la ./
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: nightly
+          path: |
+            ./${{ matrix.artifact_name }}
 
-    - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: nightly
-        path: |
-          ./${{ matrix.artifact_name }}
+      - name: Upload additional Build Artifacts
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: nightly
+          path: |
+            ./mf6io.pdf
 
-    - name: Upload additional Build Artifacts
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v2
-      with:
-        name: nightly
-        path: |
-          ./mf6io.pdf
+      - name: exclude unused files from cache on windows
+        if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          .github/intel-scripts/cache_exclude_windows.sh
 
-    - name: exclude unused files from cache on windows
-      if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        .github/intel-scripts/cache_exclude_windows.sh
-
-    - name: exclude unused files from cache on linux
-      if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/cache_exclude_linux.sh
+      - name: exclude unused files from cache on linux
+        if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/cache_exclude_linux.sh
 
   # make the release if previous job was successful
   release:
@@ -270,58 +246,58 @@ jobs:
       github.event_name == 'push' || github.event_name == 'schedule'
 
     steps:
-    - name: Delete Older Releases
-      uses: dev-drprasad/delete-older-releases@v0.2.0
-      with:
-        keep_latest: 30
-        delete_tags: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 30
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: nightly
-        path: ./nightly/
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: nightly
+          path: ./nightly/
 
-    - name: List files in the artifact directory
-      shell: bash
-      run: |
-        pwd
-        ls -l ./nightly/
+      - name: List files in the artifact directory
+        shell: bash
+        run: |
+          pwd
+          ls -l ./nightly/
 
-    - name: Get Current Time
-      uses: 1466587594/get-current-time@v2
-      id: current-time
-      with:
-        format: YYYYMMDD
+      - name: Get Current Time
+        uses: josStorer/get-current-time@v2.0.0
+        id: current-time
+        with:
+          format: YYYYMMDD
 
-    - name: Use current time
-      env:
-        TIME: "${{ steps.current-time.outputs.time }}"
-        F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
-      run: echo $TIME $F_TIME
+      - name: Use current time
+        env:
+          TIME: "${{ steps.current-time.outputs.time }}"
+          F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        run: echo $TIME $F_TIME
 
-    - name: Create a Release
-      uses: ncipollo/release-action@v1.8.0
-      with:
-        tag: ${{ steps.current-time.outputs.formattedTime }}
-        name: ${{ steps.current-time.outputs.formattedTime }} nightly build
-        body: "OneAPI version of Intel ifort compiler used to compile executables for all operating systems."
-        draft: false
-        allowUpdates: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a Release
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          tag: ${{ steps.current-time.outputs.formattedTime }}
+          name: ${{ steps.current-time.outputs.formattedTime }} nightly build
+          body: "OneAPI version of Intel ifort compiler used to compile executables for all operating systems."
+          draft: false
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Upload compiled executables to the latest GitHub release
-      uses: svenstaro/upload-release-action@2.2.0
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ./nightly/*
-        tag: ${{ steps.current-time.outputs.formattedTime }}
-        overwrite: true
-        file_glob: true
+      - name: Upload compiled executables to the latest GitHub release
+        uses: svenstaro/upload-release-action@2.3.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./nightly/*
+          tag: ${{ steps.current-time.outputs.formattedTime }}
+          overwrite: true
+          file_glob: true
 
-    - name: Delete Artifact
-      uses: GeekyEggo/delete-artifact@v1.0.0
-      with:
-        name: nightly
+      - name: Delete Artifact
+        uses: GeekyEggo/delete-artifact@v1.0.0
+        with:
+          name: nightly

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -136,7 +136,7 @@ jobs:
         working-directory: modflow6/distribution
         shell: cmd
         run: |
-          call ../../.github/intel-scripts/build_windows.bat fortran $VS_VER
+          call "../../.github/intel-scripts/build_windows.bat"
           python build_nightly.py
 
       - name: Move the build zip file

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: Move the build zip file
         run: |
+          ls -l ./modflow6/distribution/temp/
           mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./
 

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -156,7 +156,6 @@ jobs:
 
       - name: Install TeX Live
         if: runner.os == 'Linux'
-        shell: bash
         run: |
           sudo apt-get update
           sudo apt install texlive-latex-extra texlive-science texlive-font-utils
@@ -205,7 +204,6 @@ jobs:
 
       - name: Move the LaTeX document
         if: runner.os == 'Linux'
-        shell: bash
         run: |
           ls -la ./modflow6/doc/mf6io/
           mv ./modflow6/doc/mf6io/mf6io.pdf mf6io.pdf
@@ -228,7 +226,6 @@ jobs:
 
       - name: exclude unused files from cache on windows
         if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-        shell: bash
         run: |
           .github/intel-scripts/cache_exclude_windows.sh
 
@@ -242,6 +239,9 @@ jobs:
     name: Make a nightly release
     needs: build_for_os
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
 
     if:
       github.event_name == 'push' || github.event_name == 'schedule'
@@ -262,7 +262,6 @@ jobs:
           path: ./nightly/
 
       - name: List files in the artifact directory
-        shell: bash
         run: |
           pwd
           ls -l ./nightly/

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -136,11 +136,12 @@ jobs:
         working-directory: modflow6/distribution
         shell: cmd
         run: |
-          call "../../.github/intel-scripts/build_windows.bat fortran $VS_VER"
+          ../../.github/intel-scripts/build_windows.bat fortran $VS_VER
           python build_nightly.py
 
       - name: Move the build zip file
         run: |
+          ls -l ./modflow6/distribution/
           ls -l ./modflow6/distribution/temp/
           mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -136,14 +136,14 @@ jobs:
         working-directory: modflow6/distribution
         shell: cmd
         run: |
-          ../../.github/intel-scripts/build_windows.bat fortran $VS_VER
+          call ../../.github/intel-scripts/build_windows.bat fortran $VS_VER
           python build_nightly.py
 
       - name: Move the build zip file
         run: |
           ls -l ./modflow6/distribution/
-          ls -l ./modflow6/distribution/temp/
-          mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
+          ls -l ./modflow6/distribution/temp_zip/
+          mv ./modflow6/distribution/temp_zip/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./
 
       # Build LaTeX document

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -141,8 +141,7 @@ jobs:
 
       - name: Move the build zip file
         run: |
-          ls -l ./modflow6/distribution/
-          ls -l ./modflow6/distribution/temp_zip/
+          ls -l ./modflow6/distribution/*
           mv ./modflow6/distribution/temp_zip/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./
 

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -32,7 +32,7 @@ jobs:
             artifact_name: linux.zip
           - os: macos-latest
             artifact_name: mac.zip
-          - os: windows-2019
+          - os: windows-latest
             artifact_name: win64.zip
     defaults:
       run:
@@ -46,6 +46,7 @@ jobs:
       LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
       MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
       FC: ifort
+      VS_VER: vs2022
 
     steps:
       - name: Checkout this github repo
@@ -128,15 +129,15 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           source /opt/intel/oneapi/setvars.sh
-          pytest -v build_nightly.py
+          python -v build_nightly.py
 
       - name: Build and zip applications on Windows
         if: runner.os == 'Windows'
         working-directory: modflow6/distribution
         shell: cmd
         run: |
-          call "../../.github/intel-scripts/ifortvars_windows.bat"
-          pytest -v build_nightly.py
+          call "../../.github/intel-scripts/build_windows.bat fortran $VS_VER"
+          python build_nightly.py
 
       - name: Move the build zip file
         run: |

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -129,7 +129,7 @@ jobs:
         working-directory: modflow6/distribution
         run: |
           source /opt/intel/oneapi/setvars.sh
-          python -v build_nightly.py
+          python build_nightly.py
 
       - name: Build and zip applications on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             artifact_name: mac.zip
             body_name: bodyFileMac
-          - os: windows-latest
+          - os: windows-2019
             artifact_name: win64.zip
             body_name: bodyFileWindows
     defaults:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -97,6 +97,7 @@ jobs:
 
       - name: Move the build zip file
         run: |
+          ls -l ./modflow6/distribution/
           ls -l ./modflow6/distribution/temp/
           mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -97,8 +97,7 @@ jobs:
 
       - name: Move the build zip file
         run: |
-          ls -l ./modflow6/distribution/
-          ls -l ./modflow6/distribution/temp_zip/
+          ls -l ./modflow6/distribution/*
           mv ./modflow6/distribution/temp_zip/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Move the build zip file
         run: |
           ls -l ./modflow6/distribution/
-          ls -l ./modflow6/distribution/temp/
-          mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
+          ls -l ./modflow6/distribution/temp_zip/
+          mv ./modflow6/distribution/temp_zip/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
           ls -l ./
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_for_os:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -95,3 +95,9 @@ jobs:
         run: |
           python build_nightly.py
 
+      - name: Move the build zip file
+        run: |
+          ls -l ./modflow6/distribution/temp/
+          mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
+          ls -l ./
+

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -94,13 +94,11 @@ jobs:
 
       - name: Print python package versions
         run: |
-          pip -V
           pip list
 
       - name: Build and zip applications
         shell: bash
         working-directory: modflow6/distribution
         run: |
-          pytest -v build_nightly.py
+          python build_nightly.py
 
-#

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -59,7 +59,6 @@ jobs:
 
       - name: Setup symbolic link to gfortran on macOS
         if: runner.os == 'macOS'
-        shell: bash
         run: |
           sudo ln -fs /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
           sudo ln -fs /usr/local/bin/gcc-10 /usr/local/bin/gcc
@@ -75,7 +74,6 @@ jobs:
       - name: Clone MODFLOW 6 repo
         run: |
           git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
-        shell: bash
 
       - name: Determine MODFLOW 6 branch
         run: |
@@ -92,12 +90,7 @@ jobs:
         run: |
           python update_flopy.py
 
-      - name: Print python package versions
-        run: |
-          pip list
-
       - name: Build and zip applications
-        shell: bash
         working-directory: modflow6/distribution
         run: |
           python build_nightly.py

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,293 +26,78 @@ jobs:
           - os: windows-latest
             artifact_name: win64.zip
             body_name: bodyFileWindows
+    defaults:
+      run:
+        shell: bash
 
     steps:
-    - name: Checkout this github repo
-      uses: actions/checkout@v2.3.4
+      - name: Checkout this github repo
+        uses: actions/checkout@v2.3.4
 
-    - name: setup-conda
-      uses: s-weigand/setup-conda@v1.0.5
-      with:
-        update-conda: true
+      - name: Setup Python
+        uses: actions/setup-python@v4.0.0
+        with:
+          python-version: 3.9
 
-    - name: Install python packages
-      run: |
-        conda info
-        conda install pip requests appdirs nose
-        # use pip to install numpy and matplotlib because of a windows issue
-        pip install numpy matplotlib
-        pip install https://github.com/modflowpy/flopy/zipball/develop
-        pip install https://github.com/modflowpy/pymake/zipball/master
+      - name: Install python packages
+        run: |
+          .github/common/install-python-std.sh
 
-    - name: Setup symbolic link to gfortran on Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo ln -fs /usr/bin/gfortran-10 /usr/local/bin/gfortran
-        sudo ln -fs /usr/bin/gcc-10 /usr/local/bin/gcc
-        sudo ln -fs /usr/bin/g++-10 /usr/local/bin/g++
+      - name: Print python package versions
+        run: |
+          pip list
 
-    - name: Setup symbolic link to gfortran on macOS
-      if: runner.os == 'macOS'
-      shell: bash
-      run: |
-        sudo ln -fs /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
-        sudo ln -fs /usr/local/bin/gcc-10 /usr/local/bin/gcc
-        sudo ln -fs /usr/local/bin/g++-10 /usr/local/bin/g++
+      - name: Setup symbolic link to gfortran on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo ln -fs /usr/bin/gfortran-10 /usr/local/bin/gfortran
+          sudo ln -fs /usr/bin/gcc-10 /usr/local/bin/gcc
+          sudo ln -fs /usr/bin/g++-10 /usr/local/bin/g++
 
-    - name: Print GNU compiler versions
-      shell: bash
-      run: |
-        gfortran --version
-        gcc --version
-        g++ --version
+      - name: Setup symbolic link to gfortran on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          sudo ln -fs /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
+          sudo ln -fs /usr/local/bin/gcc-10 /usr/local/bin/gcc
+          sudo ln -fs /usr/local/bin/g++-10 /usr/local/bin/g++
 
-    - name: Clone MODFLOW 6 repo
-      run: |
-        git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
-      shell: bash
+      - name: Print GNU compiler versions
+        shell: bash
+        run: |
+          gfortran --version
+          gcc --version
+          g++ --version
 
-    - name: Determine MODFLOW 6 branch
-      run: |
-        pwd
-        cd ./modflow6/
-        pwd
-        git branch
-        cd ../
-        pwd
-        ls ./
+      - name: Clone MODFLOW 6 repo
+        run: |
+          git clone https://github.com/MODFLOW-USGS/modflow6.git modflow6
+        shell: bash
 
-    - name: Update flopy MODFLOW 6 classes
-      run: |
-        cd ./modflow6/autotest
-        python update_flopy.py
-        cd ../../
+      - name: Determine MODFLOW 6 branch
+        run: |
+          pwd
+          cd ./modflow6/
+          pwd
+          git branch
+          cd ../
+          pwd
+          ls ./
 
-    - name: Print python package versions
-      shell: python
-      run: |
-        import sys
-        import nose
-        import numpy as np
-        import matplotlib as mpl
-        import flopy
-        import pymake
-        flopypth = flopy.__path__[0]
-        pymakepth = pymake.__path__[0]
-        print("python version:     {}".format(sys.version))
-        print("nosetest version:   {}".format(nose.__version__))
-        print("numpy version:      {}".format(np.__version__))
-        print("matplotlib version: {}".format(mpl.__version__))
-        print("flopy version:      {}".format(flopy.__version__))
-        print("pymake version:     {}".format(pymake.__version__))
-        print("")
-        print("flopy is installed in:  {}".format(flopypth))
-        print("pymake is installed in: {}".format(pymakepth))
+      - name: Update flopy MODFLOW 6 classes
+        working-directory: modflow6/autotest
+        run: |
+          python update_flopy.py
 
-    - name: Build and zip applications
-      shell: bash
-      run: |
-        cd ./modflow6/
-        nosetests -v -w ./distribution build_nightly.py
-        cd ../
+      - name: Print python package versions
+        run: |
+          pip -V
+          pip list
+
+      - name: Build and zip applications
+        shell: bash
+        working-directory: modflow6/distribution
+        run: |
+          pytest -v build_nightly.py
 
 #
-#    Uncomment the code below in the event that the oneAPI approach
-#    needs to be abandoned and we need to return to building MODFLOW 6
-#    executables with gfortran
-#    jdh - 2/22/2021
-#
-#    - name: Move the build zip file
-#      shell: bash
-#      run: |
-#        mv ./modflow6/distribution/temp/${{ matrix.artifact_name }} ./${{ matrix.artifact_name }}
-#        ls -l ./
-#
-#    - name: Build bodyFile with gfortran information
-#      shell: python
-#      run: |
-#        import sys
-#        import subprocess
-#
-#        argv = ["gfortran", "--version"]
-#        with subprocess.Popen(argv,
-#                              stdout=subprocess.PIPE,
-#                              stderr=subprocess.STDOUT,
-#                              cwd=".") as process:
-#            output, unused_err = process.communicate(timeout=10)
-#            buff = output.decode("utf-8")
-#
-#        version = buff.splitlines()[0].split()[-1]
-#        major = version.split(".")[0]
-#
-#        osname = sys.platform.lower()
-#
-#        if osname == "win32":
-#            fpth = "bodyFileWindows"
-#            msg = "Windows executables are statically linked and can be run " + \
-#                  "without gfortran being installed. In order to use the MODFLOW 6 " + \
-#                  "dynamic-link library (libmf6.dll) on Windows, the Mingw-w64 " + \
-#                  "version of gfortran version {} ".format(version) + \
-#                  "will need to be installed locally.\n\n"
-#        elif osname == "darwin":
-#            fpth = "bodyFileMac"
-#            msg = "On MacOS, the gfortran compiler used to compile the " + \
-#                  "MODFLOW 6 executables and shared object (libmf6.so) will need " + \
-#                  "to be installed locally. The MODFLOW 6 executables and shared " + \
-#                  "object were compiled on MacOS using Homebrew gfortran " + \
-#                  "version {}.\n\n".format(version)
-#        else:
-#            fpth = "bodyFileLinux"
-#            msg = "On Linux, the gfortran compiler used to compile the " + \
-#                  "MODFLOW 6 executables and shared object (libmf6.so) will need " + \
-#                  "to be installed locally. The MODFLOW 6 executables and shared " + \
-#                  "object were compiled on Linux using gfortran " + \
-#                  "version {}.\n\n".format(version)
-#
-#        f = open(fpth, "w")
-#        f.write(msg)
-#        f.close()
-#
-#    # Build LaTeX document
-#    - name: Copy the modflow6/docs directory
-#      if: runner.os == 'Linux'
-#      shell: python
-#      run: |
-#        import shutil
-#        src = "/home/runner/work/modflow6-nightly-build/modflow6-nightly-build/modflow6/doc/"
-#        dst = "./doc/"
-#        shutil.copytree(src, dst)
-#
-#    - name: Install TeX Live
-#      if: runner.os == 'Linux'
-#      shell: bash
-#      run: |
-#        sudo apt install texlive-latex-extra texlive-science texlive-font-utils
-#
-#    - name: Build mf6io latex document
-#      if: runner.os == 'Linux'
-#      shell: python
-#      run: |
-#        import sys
-#        import subprocess
-#
-#        ws = "./modflow6/doc/mf6io/"
-#        bibnam = "mf6io.nightlybuild"
-#        texnam = bibnam + ".tex"
-#        cmds = [
-#                ["pdflatex", texnam],
-#                ["bibtex", bibnam],
-#                ["pdflatex", texnam],
-#                ["pdflatex", texnam],
-#               ]
-#        for cmd in cmds:
-#            print("running command...'{}'".format(" ".join(cmd)))
-#            with subprocess.Popen(cmd,
-#                                  stdout=subprocess.PIPE,
-#                                  stderr=subprocess.STDOUT,
-#                                  cwd=ws) as process:
-#                stdout, stderr = process.communicate(timeout=10)
-#                if stdout:
-#                    stdout = stdout.decode()
-#                    print(stdout)
-#                if stderr:
-#                    print("\n\nError condition occurred:\n")
-#                    stderr = stderr.decode()
-#                    print(stderr)
-#
-#    - name: Rename and move the LaTeX document
-#      if: runner.os == 'Linux'
-#      shell: bash
-#      run: |
-#        ls -la ./modflow6/doc/mf6io/
-#        mv ./modflow6/doc/mf6io/mf6io.nightlybuild.pdf mf6io.pdf
-#        ls -la ./
-#
-#    - name: Upload a Build Artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: nightly
-#        path: |
-#          ./${{ matrix.artifact_name }}
-#          ./${{ matrix.body_name }}
-#
-#    - name: Upload additional Build Artifacts
-#      if: runner.os == 'Linux'
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: nightly
-#        path: |
-#          ./mf6io.pdf
-#
-#  # make the release if previous job was successful
-#  release:
-#    name: Make a nightly release
-#    needs: build_for_os
-#    runs-on: ubuntu-20.04
-#
-#    steps:
-#    - name: Download a Build Artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: nightly
-#        path: ./nightly/
-#
-#    - name: List files in the artifact directory
-#      shell: bash
-#      run: |
-#        pwd
-#        ls -l ./nightly/
-#
-#    - name: Concatenate os specific bodyFiles
-#      shell: bash
-#      run: |
-#        pwd
-#        cat ./nightly/bodyFileWindows ./nightly/bodyFileMac ./nightly/bodyFileLinux > bodyFile
-#        ls -l ./
-#        rm ./nightly/bodyFile*
-#        ls -l ./nightly/
-#
-#    - name: Get Current Time
-#      uses: 1466587594/get-current-time@v2
-#      id: current-time
-#      with:
-#        format: YYYYMMDD
-#
-#    - name: Use current time
-#      env:
-#        TIME: "${{ steps.current-time.outputs.time }}"
-#        F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
-#      run: echo $TIME $F_TIME
-#
-#    - name: Delete Older Releases
-#      uses: dev-drprasad/delete-older-releases@v0.1.0
-#      with:
-#        repo: MODFLOW-USGS/modflow6-nightly-build
-#        keep_latest: 7
-#        delete_tags: true
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#    - name: Create a Release
-#      uses: ncipollo/release-action@v1
-#      with:
-#        tag: ${{ steps.current-time.outputs.formattedTime }}
-#        name: ${{ steps.current-time.outputs.formattedTime }} nightly build
-#        bodyFile: bodyFile
-#        allowUpdates: true
-#        draft: false
-#        token: ${{ secrets.GITHUB_TOKEN }}
-#
-#    - name: Upload compiled executables to the latest GitHub release
-#      uses: svenstaro/upload-release-action@2.2.0
-#      with:
-#        repo_token: ${{ secrets.GITHUB_TOKEN }}
-#        file: ./nightly/*
-#        tag: ${{ steps.current-time.outputs.formattedTime }}
-#        overwrite: true
-#        file_glob: true
-#
-#    - name: Delete Artifact
-#      uses: GeekyEggo/delete-artifact@v1.0.0
-#      with:
-#        name: nightly

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -32,7 +32,7 @@ jobs:
             artifact_name: Linux.zip
           - os: macos-latest
             artifact_name: macOS.zip
-          - os: windows-2019
+          - os: windows-latest
             artifact_name: Windows.zip
     defaults:
       run:

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -153,7 +153,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          .github/intel-scripts/build_windows.bat fortran $VS_VER
+          call .github/intel-scripts/build_windows.bat fortran $VS_VER
           python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
       - name: Create an artifact of the distributions

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -48,135 +48,116 @@ jobs:
       FC: ifort
 
     steps:
-    - name: Checkout this github repo
-      uses: actions/checkout@v2.3.4
+      - name: Checkout this github repo
+        uses: actions/checkout@v2.3.4
 
-    - name: cache install ifort on linux
-      if: runner.os == 'Linux'
-      id: cache-install-linux
-      uses: actions/cache@v2
-      with:
-        path: |
-          /opt/intel/oneapi
-        key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_linux.sh') }}
+      - name: cache install ifort on linux
+        if: runner.os == 'Linux'
+        id: cache-install-linux
+        uses: actions/cache@v2
+        with:
+          path: |
+            /opt/intel/oneapi
+          key: install-${{ env.LINUX_HPCKIT_URL }}-${{ env.LINUX_FORTRAN_COMPONENTS_WEB }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_linux.sh') }}
 
-    - name: install ifort on linux
-      if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
+      - name: install ifort on linux
+        if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_linux.sh $LINUX_HPCKIT_URL $LINUX_FORTRAN_COMPONENTS_WEB
 
-    - name: cache install ifort on macos
-      if: runner.os == 'macOS'
-      id: cache-install-macos
-      uses: actions/cache@v2
-      with:
-        path: /opt/intel/oneapi
-        key: install-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_FORTRAN_COMPONENTS }}
+      - name: cache install ifort on macos
+        if: runner.os == 'macOS'
+        id: cache-install-macos
+        uses: actions/cache@v2
+        with:
+          path: /opt/intel/oneapi
+          key: install-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_FORTRAN_COMPONENTS }}
 
-    - name: install ifort on macos
-      if: runner.os == 'macOS' && steps.cache-install-macos.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_macos.sh $MACOS_HPCKIT_URL $MACOS_FORTRAN_COMPONENTS
+      - name: install ifort on macos
+        if: runner.os == 'macOS' && steps.cache-install-macos.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_macos.sh $MACOS_HPCKIT_URL $MACOS_FORTRAN_COMPONENTS
 
-    - name: cache install ifort on windows
-      if: runner.os == 'Windows'
-      id: cache-install-windows
-      uses: actions/cache@v2
-      with:
-        path: C:\Program Files (x86)\Intel\oneAPI
-        key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_windows.sh') }}
+      - name: cache install ifort on windows
+        if: runner.os == 'Windows'
+        id: cache-install-windows
+        uses: actions/cache@v2
+        with:
+          path: C:\Program Files (x86)\Intel\oneAPI
+          key: install-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-compiler-${{ hashFiles('**/.github/intel-scripts/cache_exclude_windows.sh') }}
 
-    - name: install ifort on windows
-      if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-      run: |
-        .github/intel-scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
-    - name: setup-conda
-      uses: s-weigand/setup-conda@v1.0.5
-      with:
-        update-conda: true
+      - name: install ifort on windows
+        if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
+        run: |
+          .github/intel-scripts/install_windows.bat $WINDOWS_HPCKIT_URL $WINDOWS_FORTRAN_COMPONENTS
 
-    - name: install dos2unix on linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get install dos2unix
-        dos2unix --version
+      - name: Setup Python
+        uses: actions/setup-python@v4.0.0
+        with:
+          python-version: 3.9
 
-    - name: Install TeX Live and usgslatex
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt install texlive-latex-extra texlive-science texlive-font-utils
-        sudo apt install texlive-fonts-extra
-        git clone https://github.com/MODFLOW-USGS/usgslatex.git usgslatex
-        cd ./usgslatex/usgsLaTeX
-        sudo ./install.sh --all-users
+      - name: Install python packages
+        run: |
+          .github/common/install-python-std.sh
+          pip install -r ./etc/requirements.pip.txt
+          pip install -r ./etc/requirements.usgs.txt
 
-    - name: Clone MODFLOW 6 repos
-      run: |
-        git clone --depth 1 https://github.com/MODFLOW-USGS/modflow6.git modflow6
-        git clone --depth 1 https://github.com/MODFLOW-USGS/modflow6-examples.git modflow6-examples
+      - name: Print python package versions
+        run: |
+          pip list
 
-    - name: Install python packages
-      run: |
-        conda info
-        conda install pip requests appdirs nose wheel
-        pip install -r ./etc/requirements.pip.txt
-        pip install -r ./etc/requirements.usgs.txt
-        pip install meson ninja
+      - name: install dos2unix on linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install dos2unix
+          dos2unix --version
 
-    - name: Determine MODFLOW 6 branch
-      run: |
-        pwd
-        cd ./modflow6/
-        pwd
-        git branch
-        cd ../
-        pwd
-        ls ./
+      - name: Install TeX Live and usgslatex
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt install texlive-latex-extra texlive-science texlive-font-utils
+          sudo apt install texlive-fonts-extra
+          git clone https://github.com/MODFLOW-USGS/usgslatex.git usgslatex
+          cd ./usgslatex/usgsLaTeX
+          sudo ./install.sh --all-users
 
-    - name: Print python package versions
-      shell: python
-      run: |
-        import sys
-        import nose
-        import numpy as np
-        import matplotlib as mpl
-        import flopy
-        import pymake
-        flopypth = flopy.__path__[0]
-        pymakepth = pymake.__path__[0]
-        print("python version:     {}".format(sys.version))
-        print("nosetest version:   {}".format(nose.__version__))
-        print("numpy version:      {}".format(np.__version__))
-        print("matplotlib version: {}".format(mpl.__version__))
-        print("flopy version:      {}".format(flopy.__version__))
-        print("pymake version:     {}".format(pymake.__version__))
-        print("")
-        print("flopy is installed in:  {}".format(flopypth))
-        print("pymake is installed in: {}".format(pymakepth))
+      - name: Clone MODFLOW 6 repos
+        run: |
+          git clone --depth 1 https://github.com/MODFLOW-USGS/modflow6.git modflow6
+          git clone --depth 1 https://github.com/MODFLOW-USGS/modflow6-examples.git modflow6-examples
 
-    - name: Update flopy MODFLOW 6 classes
-      run: |
-        cd ./modflow6/autotest
-        python update_flopy.py
-        cd ../../
+      - name: Determine MODFLOW 6 branch
+        run: |
+          pwd
+          cd ./modflow6/
+          pwd
+          git branch
+          cd ../
+          pwd
+          ls ./
 
-    - name: Create MODFLOW 6 distribution (Linux/Mac)
-      if: runner.os == 'Linux' || runner.os == 'macOS'
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
+      - name: Update flopy MODFLOW 6 classes
+        working-directory: modflow6/autotest
+        run: |
+          python update_flopy.py
 
-    - name: Create MODFLOW 6 distribution (Windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        call ".github/intel-scripts/ifortvars_windows.bat"
-        python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
+      - name: Create MODFLOW 6 distribution (Linux/Mac)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
-    - name: Create an artificat of the distributions
-      uses: actions/upload-artifact@v2.2.3
-      with:
-        name: ${{ runner.os }}
-        path: |
-          ./${{ runner.os }}.zip
+      - name: Create MODFLOW 6 distribution (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call ".github/intel-scripts/ifortvars_windows.bat"
+          python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
+
+      - name: Create an artifact of the distributions
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: ${{ runner.os }}
+          path: |
+            ./${{ runner.os }}.zip

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -152,7 +152,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call ".github/intel-scripts/ifortvars_windows.bat"
+          call ".github/intel-scripts/build_windows.bat fortran $VS_VER"
           python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
       - name: Create an artifact of the distributions

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -39,13 +39,14 @@ jobs:
         shell: bash
 
     env:
-      WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18417/w_HPCKit_p_2022.1.0.93_offline.exe
-      LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18438/l_HPCKit_p_2022.1.1.97_offline.sh
-      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18341/m_HPCKit_p_2022.1.0.86_offline.dmg
+      WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
+      LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh
+      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18681/m_HPCKit_p_2022.2.0.158_offline.dmg
       WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
       LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
       MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
       FC: ifort
+      VS_VER: vs2022
 
     steps:
       - name: Checkout this github repo

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -153,7 +153,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call .github/intel-scripts/build_windows.bat fortran $VS_VER
+          call ".github/intel-scripts/build_windows.bat"
           python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
       - name: Create an artifact of the distributions

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -153,7 +153,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call ".github/intel-scripts/build_windows.bat fortran $VS_VER"
+          .github/intel-scripts/build_windows.bat fortran $VS_VER
           python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
       - name: Create an artifact of the distributions


### PR DESCRIPTION
Update OneAPI installation. Update GH Actions versions for
pre-canned workflow tasks. Modified GH Actions to use standard
python instead of conda python.