### PR TITLE
ci: fix Intel OneAPI build on Windows

### DIFF
--- a/.github/common/install-python-std.sh
+++ b/.github/common/install-python-std.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 pip install wheel
-pip install requests appdirs numpy matplotlib pytest pytest-xdist meson ninja
+pip install requests appdirs numpy matplotlib pytest pytest-xdist meson!=0.63.0 ninja
 pip install https://github.com/modflowpy/flopy/zipball/develop
 pip install https://github.com/modflowpy/pymake/zipball/master


### PR DESCRIPTION
The issue is caused by the latest meson release. Exclude meson version 0.63.0.