### PR TITLE
ci: explicitly checkout develop branch of modflow6, simplify steps

### DIFF
--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v4.0.0
@@ -63,6 +63,7 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6
           path: modflow6
+          ref: develop
 
       - name: Update flopy classes
         working-directory: modflow6/autotest
@@ -78,8 +79,8 @@ jobs:
       - name: Build and zip (Windows)
         if: runner.os == 'Windows'
         working-directory: modflow6/distribution
+        shell: pwsh
         run: |
-          export PATH="/C/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64":$PATH
           python build_nightly.py
 
       - name: Move the build zip file

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6
           path: modflow6
+          ref: develop
 
       - name: Update flopy classes
         working-directory: modflow6/autotest

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6
           path: modflow6
+          ref: develop
 
       - name: Checkout modflow6 examples
         uses: actions/checkout@v3


### PR DESCRIPTION
- bump `actions/checkout` to `v3`
- use `actions/checkout` option `ref: develop`
  - the action's [default behavior](https://github.com/actions/checkout#usage) is to checkout the default branch &mdash; this makes sure MODFLOW 6 repo's `develop` branch is used for the nightly build even if the default branch changes (e.g., to `master`)
- use `pwsh` for `ifort` build on Windows (makes [system path adjustment for MSVC](https://github.com/modflowpy/install-intelfortran-action#shell-support) unnecessary)