### PR TITLE
ci: include code.json as release asset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ shapely
 wheel
 
 # USGS dependencies
-git+https://github.com/Deltares/xmipy.git@develop
 git+https://github.com/modflowpy/flopy.git@develop
 git+https://github.com/modflowpy/pymake.git@master
 git+https://github.com/MODFLOW-USGS/modflowapi.git@develop


### PR DESCRIPTION
#21 added `code.json` to the distribution archive but neglected to upload it as a release asset