### PR TITLE
fix(dependencies): remove explicit xmipy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ shapely
 wheel
 
 # USGS dependencies
-git+https://github.com/Deltares/xmipy.git@develop
 git+https://github.com/modflowpy/flopy.git@develop
 git+https://github.com/modflowpy/pymake.git@master
 git+https://github.com/MODFLOW-USGS/modflowapi.git@develop


### PR DESCRIPTION
https://github.com/MODFLOW-USGS/modflow6/pull/1149

Seems this is a `pip` issue, not Conda