### PR TITLE
ci: use dependabot to update github actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -85,7 +85,7 @@ jobs:
           ref: develop
 
       - name: Setup Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -202,7 +202,7 @@ jobs:
           ref: develop
 
       - name: Setup Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -271,7 +271,7 @@ jobs:
 
       - name: Upload mf6io docs
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: mf6io
           path: ${{ matrix.artifact_name }}/doc/mf6io.pdf
@@ -296,7 +296,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3
         with:
           path: nightly
 
@@ -304,7 +304,7 @@ jobs:
         run: ls -l nightly
 
       - name: Get time
-        uses: josStorer/get-current-time@v2.0.0
+        uses: josStorer/get-current-time@v2
         id: current-time
         with:
           format: YYYYMMDD
@@ -316,7 +316,7 @@ jobs:
         run: echo $TIME $F_TIME
 
       - name: Create release
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.current-time.outputs.formattedTime }}
           name: ${{ steps.current-time.outputs.formattedTime }} nightly build
@@ -330,7 +330,7 @@ jobs:
         run: find nightly -type f ! -name '*.zip' ! -name '*.pdf' -delete
 
       - name: Upload release assets
-        uses: svenstaro/upload-release-action@2.3.0
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: nightly/**


### PR DESCRIPTION
Also unpin some actions to specify only major version