### PR TITLE
ci: unpin github actions versions

### DIFF
--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -39,7 +39,7 @@ jobs:
           ref: develop
 
       - name: Setup Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/nightly-distribution.yml
+++ b/.github/workflows/nightly-distribution.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4.0.0
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -71,7 +71,7 @@ jobs:
         run: python make_distribution.py -mf6p ./modflow6 -mf6ep ./modflow6-examples -dp ./${{ runner.os }}
 
       - name: Create distribution artifact
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }}
           path: |


### PR DESCRIPTION
This prevents dependabot updates on minor/patch releases [like this one](https://github.com/MODFLOW-USGS/modflow6-nightly-build/pull/26), we only want minor/patch updates on actions that don't update their major tags on minor/patch releases.