### PR TITLE
ci: remove mf6.y.zdev_ from asset names

### DIFF
--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -114,9 +114,9 @@ jobs:
       - name: Prune artifacts
         working-directory: nightly
         run: |
-          echo "adding .zip suffix to distributions"
-          for f in mf*/mf*; do mv -- "$f" "$(basename $f)"; done
           echo "pruning artifacts"
+          for f in mf*/mf*; do mv -- "$f" "$(basename $f)"; done
+          for f in *.zip; do mv -- "$f" "${f##mf*dev_}"; done
           find mf* -type d -delete
           rm -rf bin-*
           rm -rf release_notes


### PR DESCRIPTION
Allows stable download links consistent with the executables repo releases, e.g. https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/latest/download/win64.zip. Distribution assets will be named

- win64.zip
- mac.zip
- linux.zip

[Sample release here](https://github.com/w-bonelli/modflow6-nightly-build/releases/tag/20230626). Thanks @Hofer-Julian for the suggestion