### PR TITLE
fix: don't append dev to version string

### DIFF
--- a/.github/workflows/full-dist-test.yml
+++ b/.github/workflows/full-dist-test.yml
@@ -61,4 +61,4 @@ jobs:
       developmode: false
       full: true
       run_tests: false
-      version: "${{ needs.get_version.outputs.version }}dev"
+      version: "${{ needs.get_version.outputs.version }}"

--- a/.github/workflows/nightly-build-intel.yml
+++ b/.github/workflows/nightly-build-intel.yml
@@ -65,7 +65,7 @@ jobs:
         id: get_version
         run: |
           ver=$(python update_version.py -g)
-          echo "version=${ver}dev" >> "$GITHUB_OUTPUT"
+          echo "version=${ver}" >> "$GITHUB_OUTPUT"
 
   make_dist:
     name: Make development distribution

--- a/README.md
+++ b/README.md
@@ -23,23 +23,7 @@ The `develop` branch of the [MODFLOW 6 repository](https://github.com/MODFLOW-US
 
 ## Distribution contents
 
-The nightly builds are available as operating-system specific [distributions](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/latest). Each includes an internal directory `mf6.y.zdev_<ostag>` with two subdirectories, `bin` and `doc`, and a `code.json` metadata file. 
-
-**mf6.y.zdev_...**
-
-- **code.json**: a JSON file with version information and other metadata
-
-- **bin/**
-
-    1. **mf6[.exe]**: MODFLOW 6
-    2. **mf5to6[.exe]**: the MODFLOW 5 to 6 converter
-    3. **zbud6[.exe]**: the zone budget utility for MODFLOW 6
-    4. **libmf6[.dll/so/dylib]**: a dynamic-linked library or shared object version of MODFLOW 6
-
-- **doc/**
-
-    1. **release.pdf**: release notes
-    2. **mf6io.pdf**: input/output documentation
+The nightly builds are available as operating-system specific [distributions](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/latest) including binaries, MODFLOW 6 input/output documentation, development notes, and a `code.json` metadata file. 
 
 ### Binaries
 


### PR DESCRIPTION
The nightly build was broken by https://github.com/MODFLOW-USGS/modflow6/pull/1283. The modflow6 `develop` branch now has a version string ending with ".dev0", no need to manually append "dev" to the version here. Also don't hard-code the dist folder structure in the README in case it changes.