### PR TITLE
ci: don't mention build specifics

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,4 @@
-name: MODFLOW 6 intel nightly build
+name: MODFLOW 6 nightly build
 # Only allow one development build to run at once.
 # If a new build is triggered, the previous build
 # is cancelled. This allows modflow6 CI to trigger
@@ -140,7 +140,7 @@ jobs:
         with:
           tag: ${{ steps.current-time.outputs.formattedTime }}
           name: ${{ steps.current-time.outputs.formattedTime }} development build
-          body: "MODFLOW 6 development build, compiled with Intel Fortran. A statically linked distribution for ARM macs, built with GNU Fortran, is also included."
+          body: "MODFLOW 6 development build."
           draft: false
           allowUpdates: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Nightly development build of MODFLOW 6.
 
 [![Latest tag](https://img.shields.io/github/tag/MODFLOW-USGS/modflow6-nightly-build.svg)](https://github.com/MODFLOW-USGS/modflow6-nightly-build/tags/latest)
-[![MODFLOW 6 intel nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/nightly-build-intel.yml/badge.svg)](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/nightly-build-intel.yml)
+[![MODFLOW 6 nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/nightly-build.yml/badge.svg)](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/nightly-build.yml)
 [![MODFLOW 6 full distribution test](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/full-dist-test.yml/badge.svg)](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/workflows/full-dist-test.yml)
 
 The `develop` branch of the [MODFLOW 6 repository](https://github.com/MODFLOW-USGS/modflow6) contains bug fixes and new functionality that may be incorporated into the next [approved MODFLOW 6 release](https://www.usgs.gov/software/modflow-6-usgs-modular-hydrologic-model). Minimal development distributions are posted regularly to [nightly build repository](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases/latest) &mdash; these should be considered preliminary, provisional release candidates for the next version of MODFLOW 6.


### PR DESCRIPTION
Use generic language to avoid needing updates as distributions evolve

* rename nightly-build-intel -> nightly-build
* remove mention of intel from release post