### PR TITLE
ci: add workflow_dispatch triggers

### DIFF
--- a/.github/workflows/full-dist-test.yml
+++ b/.github/workflows/full-dist-test.yml
@@ -14,6 +14,9 @@ on:
       - master
     paths-ignore:
       - '**.md'
+  # workflow_dispatch trigger to start release via GitHub UI or CLI,
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
 jobs:
   get_version:
     name: Get current version

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -30,6 +30,9 @@ on:
   # if the merge-triggered CI fails or by CI on open PRs.
   repository_dispatch:
     types: [build]
+  # workflow_dispatch trigger to start release via GitHub UI or CLI,
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
 jobs:
   get_version:
     name: Get current version
@@ -89,7 +92,7 @@ jobs:
       run:
         shell: bash
     # don't create a release post if triggering event is pull request
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name != 'pull_request'
     steps:
 
       - name: Delete Older Releases


### PR DESCRIPTION
Add a `workflow_dispatch` trigger to both workflows, allowing manual runs from the UI or CLI.